### PR TITLE
[FIX] bce_derivate: fix cpu signature

### DIFF
--- a/Kinho/lib/cpu/bce_derivate.py
+++ b/Kinho/lib/cpu/bce_derivate.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def bce_derivate(predict: np.ndarray, target: np.ndarray) -> np.ndarray:
+def bce_derivate(predicts: np.ndarray, targets: np.ndarray) -> np.ndarray:
     """BCE - Binary Cross Entropy Derivate
 
         BCE = (1.0 / BATCH) * SUM(1<=i<=BATCH)[ (P[i] - Y[i]) / (P[i] * (1.0 - P[i])) ]
@@ -10,15 +10,15 @@ def bce_derivate(predict: np.ndarray, target: np.ndarray) -> np.ndarray:
             P[i] = predict[i]
 
     Args:
-        predict (np.ndarray): [BATCH][1][N]
-        target (np.ndarray): [BATCH][1][N]
+        predicts (np.ndarray): [BATCH][1][N]
+        targets (np.ndarray): [BATCH][1][N]
 
     Returns:
         np.ndarray: [BATCH][1][N]
     """
-    BATCH = predict.shape[0]
+    BATCH = predicts.shape[0]
 
-    res = (predict - target) / (predict * (1.0 - predict))
+    res = (predicts - targets) / (predicts * (1.0 - predicts))
     res = res / BATCH
 
     return res


### PR DESCRIPTION
```py
# before
def bce_derivate(predict: np.ndarray, target: np.ndarray) -> np.ndarray
    pass
# after
def bce_derivate(predicts: np.ndarray, targets: np.ndarray) -> np.ndarray
    pass
```